### PR TITLE
SOLR-47 Fix DropTriggers creation function

### DIFF
--- a/admin/GenerateSQLScripts.pl
+++ b/admin/GenerateSQLScripts.pl
@@ -317,7 +317,7 @@ sub process_triggers
     close FILE;
 
     my @triggers;
-    while ($create_triggers_sql =~ m/CREATE (?:CONSTRAINT )?TRIGGER\s+"?([a-z0-9_]+)"?\s+.*?\s+ON\s+"?([a-z0-9_]+)"?.*?;/gsi) {
+    while ($create_triggers_sql =~ m/CREATE (?:CONSTRAINT )?TRIGGER\s+"?([a-z0-9_]+)"?\s+.*?\s+ON\s+"?([a-z0-9_\.]+)"?.*?;/gsi) {
         push @triggers, [$1, $2];
     }
 


### PR DESCRIPTION
Allow the regex to parse the schema when specified.
See https://github.com/metabrainz/sir/blob/master/sir/trigger_generation/sql_generator.py#L47